### PR TITLE
feat: Add author profile component below blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -11,8 +11,9 @@ export async function generateStaticParams() {
   }))
 }
 
-export function generateMetadata({ params }) {
-  let post = getBlogPosts().find((post) => post.slug === params.slug)
+export async function generateMetadata({ params }) {
+  let { slug } = await params
+  let post = getBlogPosts().find((post) => post.slug === slug)
   if (!post) {
     return
   }
@@ -51,8 +52,9 @@ export function generateMetadata({ params }) {
   }
 }
 
-export default function Blog({ params }) {
-  let post = getBlogPosts().find((post) => post.slug === params.slug)
+export default async function Blog({ params }) {
+  let { slug } = await params
+  let post = getBlogPosts().find((post) => post.slug === slug)
 
   if (!post) {
     notFound()

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,7 +1,14 @@
 import { notFound } from 'next/navigation'
 import { CustomMDX } from 'app/components/mdx'
+import { AuthorProfile } from 'app/components/AuthorProfile'
 import { formatDate, getBlogPosts } from 'app/blog/utils'
 import { baseUrl } from 'app/sitemap'
+
+const author = {
+  name: 'My Name',
+  bio: '블로그 운영자입니다. 개발, 글쓰기, 그리고 새로운 것들을 탐구하는 것을 좋아합니다.',
+  avatarUrl: 'https://github.com/github.png',
+}
 
 export async function generateStaticParams() {
   let posts = getBlogPosts()
@@ -95,6 +102,7 @@ export default async function Blog({ params }) {
       <article className="prose">
         <CustomMDX source={post.content} />
       </article>
+      <AuthorProfile author={author} />
     </section>
   )
 }

--- a/app/components/AuthorProfile.tsx
+++ b/app/components/AuthorProfile.tsx
@@ -1,0 +1,29 @@
+type Author = {
+  name: string
+  bio: string
+  avatarUrl: string
+}
+
+type AuthorProfileProps = {
+  author: Author
+}
+
+export function AuthorProfile({ author }: AuthorProfileProps) {
+  return (
+    <div className="flex items-start gap-4 mt-12 pt-8 border-t border-neutral-200 dark:border-neutral-700">
+      <img
+        src={author.avatarUrl}
+        alt={author.name}
+        className="w-14 h-14 rounded-full object-cover shrink-0"
+      />
+      <div>
+        <p className="font-bold text-neutral-900 dark:text-neutral-100">
+          {author.name}
+        </p>
+        <p className="text-sm text-neutral-600 dark:text-neutral-400 mt-1">
+          {author.bio}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/components/AuthorProfile.tsx
+++ b/app/components/AuthorProfile.tsx
@@ -18,7 +18,7 @@ export function AuthorProfile({ author }: AuthorProfileProps) {
       />
       <div>
         <p className="font-bold text-neutral-900 dark:text-neutral-100">
-          {author.name}
+          {author.name} Sir
         </p>
         <p className="text-sm text-neutral-600 dark:text-neutral-400 mt-1">
           {author.bio}

--- a/claude.md
+++ b/claude.md
@@ -1,0 +1,19 @@
+# 개인 블로그 프로젝트 Git 워크플로우 규칙
+
+## 1. Repository
+- **GitHub Repository:** `[여러분의-GitHub-ID]/my-personal-blog`
+- **Main Branch:** `main`
+
+## 2. Branching Strategy
+- 모든 기능 개발은 `feature/[이슈번호]-[간단-설명-kebab-case]` 형식의 브랜치에서 진행한다.
+- 이슈 번호가 없는 간단한 수정은 `fix/[간단-설명]` 또는 `chore/[간단-설명]` 브랜치를 사용한다.
+
+## 3. Commit Message Convention
+- 모든 커밋 메시지는 **Conventional Commits** 명세를 따른다.
+- (예: `feat: Add author profile component`, `fix: Correct typo in footer`)
+- 커밋 본문에는 변경 이유를 명확히 서술하고, 관련된 GitHub 이슈를 `Closes #[이슈번호]` 형식으로 반드시 포함한다.
+
+## 4. Pull Request (PR) Process
+- 모든 코드는 `main` 브랜치로 직접 푸시할 수 없으며, 반드시 PR을 통해 코드 리뷰를 받아야 한다.
+- PR 제목은 커밋 메시지와 동일한 형식을 따른다.
+- PR 본문은 `.github/PULL_REQUEST_TEMPLATE.md` 템플릿을 사용한다.


### PR DESCRIPTION
## 📝 변경사항

### 주요 변경사항
- [x] UI/UX 개선

### 상세 설명
모든 블로그 게시글 본문 하단에 글쓴이의 프로필(아바타 이미지, 이름, 짧은 소개)을 보여주는 섹션을 추가합니다.

## 🔍 변경된 파일

- `app/components/AuthorProfile.tsx` - 신규 작가 프로필 컴포넌트
- `app/blog/[slug]/page.tsx` - AuthorProfile 컴포넌트 연결

## 🧪 테스트

- [ ] 로컬에서 개발 서버 실행 확인
- [ ] 블로그 포스트 렌더링 확인
- [ ] 반응형 디자인 확인

### 테스트 방법
```bash
pnpm dev
pnpm build
pnpm lint
```

## ✅ 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체적으로 코드를 검토했습니다
- [x] 이 변경사항이 프로덕션에 배포되어도 안전합니다

## 📚 관련 이슈

Closes #2